### PR TITLE
Add /health endpoint for service activity and database check

### DIFF
--- a/app.py
+++ b/app.py
@@ -568,7 +568,8 @@ def health_check():
     """Lightweight health check endpoint — used by UptimeRobot to keep
     Render awake and Supabase active by making a minimal DB query."""
     try:
-        db.session.execute(text("SELECT 1"))
+        result = db.session.execute(text("SELECT 1"))
+        result.scalar()
         return jsonify({"status": "ok", "db": "connected"}), 200
     except Exception:
         app.logger.exception("Health check failed")

--- a/app.py
+++ b/app.py
@@ -563,6 +563,17 @@ def get_zones_cached():
 # --- Routes ---
 
 
+@app.route("/health")
+def health_check():
+    """Lightweight health check endpoint — used by UptimeRobot to keep
+    Render awake and Supabase active by making a minimal DB query."""
+    try:
+        db.session.execute(text("SELECT 1"))
+        return jsonify({"status": "ok", "db": "connected"}), 200
+    except Exception as e:
+        return jsonify({"status": "error", "detail": str(e)}), 500
+
+
 @app.route("/")
 def index():
     """Landing page - shows different content based on authentication status"""

--- a/app.py
+++ b/app.py
@@ -570,8 +570,9 @@ def health_check():
     try:
         db.session.execute(text("SELECT 1"))
         return jsonify({"status": "ok", "db": "connected"}), 200
-    except Exception as e:
-        return jsonify({"status": "error", "detail": str(e)}), 500
+    except Exception:
+        app.logger.exception("Health check failed")
+        return jsonify({"status": "error"}), 500
 
 
 @app.route("/")


### PR DESCRIPTION
This pull request introduces a new lightweight health check endpoint to the application. This endpoint allows external services (like UptimeRobot) to monitor the application's availability and ensure the database connection is active, helping keep both the Render and Supabase services awake.

New endpoint:

* Added a `/health` route to provide a JSON response indicating application and database connectivity status, returning HTTP 200 on success and 500 on failure.